### PR TITLE
Created pieces model, updated games and users models

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,3 +1,7 @@
 class Game < ActiveRecord::Base
+	has_many :pieces
+	belongs_to :white_player, :class_name => 'User'
+	belongs_to :black_player, :class_name => 'User'
+
   validates :name, :presence => true
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -1,0 +1,4 @@
+class Piece < ActiveRecord::Base
+	belongs_to :player, :class_name => 'User'
+	belongs_to :game
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ActiveRecord::Base
+	has_many :games
+	has_many :pieces
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/db/migrate/20151116194336_add_details_to_games.rb
+++ b/db/migrate/20151116194336_add_details_to_games.rb
@@ -1,0 +1,6 @@
+class AddDetailsToGames < ActiveRecord::Migration
+  def change
+    add_column :games, :white_player_id, :integer
+    add_column :games, :black_player_id, :integer
+  end
+end

--- a/db/migrate/20151116201416_create_pieces.rb
+++ b/db/migrate/20151116201416_create_pieces.rb
@@ -1,0 +1,14 @@
+class CreatePieces < ActiveRecord::Migration
+  def change
+    create_table :pieces do |t|
+      t.integer :x_position
+      t.integer :y_position
+      t.string :color
+      t.integer :player_id
+      t.integer :game_id
+      t.string :type
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20151117002144_remove_color_from_pieces.rb
+++ b/db/migrate/20151117002144_remove_color_from_pieces.rb
@@ -1,0 +1,5 @@
+class RemoveColorFromPieces < ActiveRecord::Migration
+  def change
+    remove_column :pieces, :color, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,13 +11,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151113044308) do
+ActiveRecord::Schema.define(version: 20151116201416) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "games", force: true do |t|
     t.string   "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "white_player_id"
+    t.integer  "black_player_id"
+  end
+
+  create_table "pieces", force: true do |t|
+    t.integer  "x_position"
+    t.integer  "y_position"
+    t.string   "color"
+    t.integer  "player_id"
+    t.integer  "game_id"
+    t.string   "type"
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151116201416) do
+ActiveRecord::Schema.define(version: 20151117002144) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,7 +27,6 @@ ActiveRecord::Schema.define(version: 20151116201416) do
   create_table "pieces", force: true do |t|
     t.integer  "x_position"
     t.integer  "y_position"
-    t.string   "color"
     t.integer  "player_id"
     t.integer  "game_id"
     t.string   "type"

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -1,4 +1,12 @@
-FactoryGirl.define do  
+FactoryGirl.define do  factory :piece do
+    x_position 1
+y_position 1
+color "MyString"
+player_id 1
+game_id 1
+type ""
+  end
+  
 
   factory :game do
     name  "test"

--- a/test/models/piece_test.rb
+++ b/test/models/piece_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PieceTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This commit adds or updates the models according to our data model document:
https://docs.google.com/spreadsheets/d/1-CnCRv_20EwELNMKBxureLXEerqr8c-NXoimBD6pyVc/edit#gid=0

In creating the association between pieces/games and users I kept the terms player, white_player, black_player so that the chess game logic will be clearer.  However, I did not create a Player model that inherits from User; at least for the basic functionality I didn't foresee having users who aren't players.

I included both an x and y coordinate integer on the pieces instead of an absolute coordinate

I put foreign keys for two separate user IDs on the games table.  This should work so that a game belongs to exactly two users while a user can be in many games without having to create a many-to-many relationship.