### PR TITLE
Obstructed method

### DIFF
--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -2,30 +2,55 @@ class Piece < ActiveRecord::Base
   belongs_to :player, class_name: 'User'
   belongs_to :game
 
-  LegalVectors = [-9, -8, -7, -1, 1, 7, 8, 9]
+  ##
+  # In order to calculate the vectors, we essentially need to 
+  # flatten the chess board, converting the position of the piece
+  # from x,y coordinates to a number between 0 and 63. Since
+  # the destination square of a move will be given in x,y coords,
+  # we flatten that as well. 
 
   def flat_position
-  	#self.x_position + self.y_position * 8
     flat_destination(self.x_position, self.y_position)
   end
 
   def flat_destination(x,y)
   	x + y * 8
   end
-  # Instead of calculating x + y * 8, Consider using a 2D array instead:
-  # Coords = [[0,1,2,3,4,5,6,7],[8,9,10,11...]...[...60,61,62,63]]
-  # Then call Coords[y][x]
-  # Coords[0][0] => 0, Coords[3][5] => 29, Coords[7][7] => 63
+
+  ##
+  # Calculate the number of squares a piece has to move to get to 
+  # a destination. Treat diagonal moves the same as horizontal/vertical, 
+  # i.e. 3 squares diagonally is the same 'distance' as 3 squares 
+  # horizontally or vertically.
 
   def distance_to(x,y)
   	[(self.x_position - x).abs, (self.y_position - y).abs].max
   end
+
+  ##
+  # Vector_to yields a particular ratio, namely, the difference between
+  # a piece's position and another square, divided by their distance 
+  # from each other.  Prevent calculating the vector to a piece's own 
+  # square, which would raise a ZeroDivisionError.
 
   def vector_to(x,y)
   	unless self.distance_to(x,y) == 0
   		(self.flat_position - flat_destination(x,y))/self.distance_to(x,y)
   	end
   end
+
+  ##
+  # In chess, all moves that can be obstructed have one of the 
+  # following 8 vectors.
+
+  LegalVectors = [-9, -8, -7, -1, 1, 7, 8, 9]
+
+  ##
+  # Calculate if a move is obstructed for a particular piece to a 
+  # particular square. "Are there any pieces on the board that lie 
+  # along the same vector as the move but that are closer to the piece 
+  # than the destination square?"  Raise an exception if the move 
+  # cannot be obstructed (a knight's move or illegal move)
 
   def is_obstructed?(x,y)
   	if LegalVectors.include?(self.vector_to(x,y))

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -2,8 +2,9 @@ class Piece < ActiveRecord::Base
   belongs_to :player, class_name: 'User'
   belongs_to :game
 
-  def flat_position
+  LegalVectors = [-9, -8, -7, -1, 1, 7, 8, 9]
 
+  def flat_position
   	#self.x_position + self.y_position * 8
     flat_destination(self.x_position, self.y_position)
   end
@@ -27,7 +28,7 @@ class Piece < ActiveRecord::Base
   end
 
   def is_obstructed?(x,y)
-  	if [-9, -8, -7, -1, 1, 7, 8, 9].include?(self.vector_to(x,y))
+  	if LegalVectors.include?(self.vector_to(x,y))
 	  	self.game.pieces.any? do |piece|
 	  		self.vector_to(x,y) == self.vector_to(piece.x_position, piece.y_position) &&
 	  		self.distance_to(x,y) > self.distance_to(piece.x_position,piece.y_position)

--- a/test/models/piece_test.rb
+++ b/test/models/piece_test.rb
@@ -3,15 +3,30 @@ require 'test_helper'
 class PieceTest < ActiveSupport::TestCase
   setup :initialize_board
 
-  test "move is correctly identified as obstructed" do
+  test "white bishop is not obstructed" do
     assert_not @white_bishop.is_obstructed?(2,3)
+  end
+
+  test "black bishop is obstructed" do
     assert @black_bishop.is_obstructed?(3,2)
+  end
+
+  test "black rook is obstructed" do
     assert @black_rook.is_obstructed?(0,3)
+  end
+
+  test "knight cannot be obstructed" do
     runtime_error = assert_raises(RuntimeError) do
-	  	@white_knight.is_obstructed?(1,4)
-	  end
-		assert_equal("Invalid input. Not diagonal, horizontal, or vertical.", runtime_error.message)
+      @white_knight.is_obstructed?(1,4)
+    end
+    assert_equal("Invalid input. Not diagonal, horizontal, or vertical.", runtime_error.message)
+  end
+
+  test "not obstructed piece in destination" do
     assert_not @white_rook.is_obstructed?(0,5)
+  end
+
+  test "not obstructed no piece in destination" do
     assert_not @white_rook.is_obstructed?(2,7)
   end
 

--- a/test/models/piece_test.rb
+++ b/test/models/piece_test.rb
@@ -1,29 +1,39 @@
 require 'test_helper'
 
 class PieceTest < ActiveSupport::TestCase
+  setup :initialize_board
+
   test "move is correctly identified as obstructed" do
-  	game = Game.create(:name => 'lolomg')
-  	black_bishop = game.pieces.find{|piece| piece.x_position == 5 && piece.y_position == 0}
-  	black_pawn = game.pieces.find{|piece| piece.x_position == 2 && piece.y_position == 1}
-  	black_rook = game.pieces.find{|piece| piece.x_position == 0 && piece.y_position == 0}
-		white_bishop = game.pieces.find{|piece| piece.x_position == 2 && piece.y_position == 7}
-  	white_knight = game.pieces.find{|piece| piece.x_position == 1 && piece.y_position == 7}
-  	white_rook = game.pieces.find{|piece| piece.x_position == 0 && piece.y_position == 7}
-  	white_pawn = game.pieces.find{|piece| piece.x_position == 0 && piece.y_position == 6}
-  	white_pawn.destroy
-  	white_bishop.update_attributes(:x_position => 0, :y_position => 5)
-  	white_knight.update_attributes(:x_position => 3, :y_position => 3)
-  	black_pawn.update_attributes(:x_position => 2, :y_position => 3)
-
-
-    refute white_bishop.is_obstructed?(2,3)
-    assert black_bishop.is_obstructed?(3,2)
-    assert black_rook.is_obstructed?(0,3)
+    assert_not @white_bishop.is_obstructed?(2,3)
+    assert @black_bishop.is_obstructed?(3,2)
+    assert @black_rook.is_obstructed?(0,3)
     runtime_error = assert_raises(RuntimeError) do
-	  	white_knight.is_obstructed?(1,4)
+	  	@white_knight.is_obstructed?(1,4)
 	  end
 		assert_equal("Invalid input. Not diagonal, horizontal, or vertical.", runtime_error.message)
-    refute white_rook.is_obstructed?(0,5)
-    refute white_rook.is_obstructed?(2,7)
+    assert_not @white_rook.is_obstructed?(0,5)
+    assert_not @white_rook.is_obstructed?(2,7)
+  end
+
+  private
+
+  def initialize_board
+    # create a game and the 32 pieces, select pieces to test
+    @game = Game.create(:name => 'lolomg')
+    @black_bishop = @game.pieces.find{|piece| piece.x_position == 5 && piece.y_position == 0}
+    @black_pawn = @game.pieces.find{|piece| piece.x_position == 2 && piece.y_position == 1}
+    @black_rook = @game.pieces.find{|piece| piece.x_position == 0 && piece.y_position == 0}
+    @white_bishop = @game.pieces.find{|piece| piece.x_position == 2 && piece.y_position == 7}
+    @white_knight = @game.pieces.find{|piece| piece.x_position == 1 && piece.y_position == 7}
+    @white_rook = @game.pieces.find{|piece| piece.x_position == 0 && piece.y_position == 7}
+    @white_pawn = @game.pieces.find{|piece| piece.x_position == 0 && piece.y_position == 6}
+    # remove the pawn at A7 from the board
+    @white_pawn.destroy
+    # move the bishop from C8 to A6 
+    @white_bishop.update_attributes(:x_position => 0, :y_position => 5)
+    # move the knight from B8 to D4
+    @white_knight.update_attributes(:x_position => 3, :y_position => 3)
+    # move the pawn from C2 to C4
+    @black_pawn.update_attributes(:x_position => 2, :y_position => 3)
   end
 end


### PR DESCRIPTION
I've been pushing different versions of this up in other branches, here I've merged in the changes from branches 'obstructed' and 'is-obstructed'.
The code isn't self explanatory (which is a problem and I'd love some help fixing it up as much as possible)
Here is a link to an 8x8 grid I use to visualize:

https://docs.google.com/spreadsheets/d/1A4bjZJR9hDEzTMezr2-oKYwiK1P_JhCHOymZLo9dkmo/edit#gid=0&vpid=A1

Flat_position and flat_destination methods simply convert the x/y coordinates of a piece or a destination square into a number 0 to 63.
Distance_to calculates the number of squares a piece has to move to get to a destination.  It treats a diagonal moves the same as horizontal/vertical, i.e. 3 squares diagonally is the same 'distance' as 3 squares horizontally or vertically.
Vector_to yields a particular ratio, namely, the difference between a piece's position and another square, divided by their distance from each other.
If you look at the 8x8 grid you'll see, for instance, that if you move from square 28 diagonally up and to the right, you'll move to 37, then 46, then 55; each move is +9.  If you instead move vertically down (27, 26, 25, 24) each move is -1.  Those are the vectors, and on a chess board all moves that can be obstructed have one of 8 vectors: [-9, -8, -7, -1, 1, 7, 8, 9].
(The unless statement prevents one from calculating the vector to a piece's own square, which would raise a ZeroDivisionError)
To calculate if a move is obstructed for a particular piece to a particular square, you ask: Are there any pieces on the board that lie along the same vector as the move but that are closer to the piece than the destination square?