### PR TITLE
Add pieces controller, edit and update actions

### DIFF
--- a/app/assets/javascripts/pieces.js.coffee
+++ b/app/assets/javascripts/pieces.js.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/pieces.css.scss
+++ b/app/assets/stylesheets/pieces.css.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the pieces controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -1,0 +1,14 @@
+class PiecesController < ApplicationController
+	def edit
+    @piece = Piece.find(params[:id])
+    @game = @piece.game
+	end
+
+	def update
+    @piece = Piece.find(params[:id])
+    @game = @piece.game
+    @piece.update_attributes(:x_position => params[:x_position],
+    	:y_position => params[:y_position])
+    redirect_to game_path(@game)
+	end
+end

--- a/app/helpers/pieces_helper.rb
+++ b/app/helpers/pieces_helper.rb
@@ -1,0 +1,2 @@
+module PiecesHelper
+end

--- a/app/views/pieces/edit.html.erb
+++ b/app/views/pieces/edit.html.erb
@@ -7,13 +7,13 @@
 			<% 8.times do %>
 				<% piece = @game.pieces.find{|piece| piece.x_position == file && piece.y_position == rank} %>
 				<td>
-					<% if piece %>						
-						<%= link_to edit_piece_path(piece) do %>
-							<div style="height:100%;width:100%">
+					<%= link_to piece_path(@piece, :params => {x_position: file, y_position: rank}), method: :put do %>
+						<div style="height:100%;width:100%">
+							<% if piece %>
 								<%= image_tag "#{piece.color.downcase}-#{piece.type.downcase}.svg", :alt => "#{piece.color} #{piece.type}" %>
-					    </div>
-					  <% end %>
-					<% end %>
+						  <% end %>
+				    </div>
+				  <% end %>
 				</td>
 				<% file +=1 %>
 			<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Chess::Application.routes.draw do
   devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }
 
   resources :games, only: [:new, :create, :show]
+  resources :pieces, only: [:edit, :update]
   root 'games#index'
 
   # The priority is based upon order of creation: first created -> highest priority.

--- a/test/controllers/pieces_controller_test.rb
+++ b/test/controllers/pieces_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PiecesControllerTest < ActionController::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/helpers/pieces_helper_test.rb
+++ b/test/helpers/pieces_helper_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class PiecesHelperTest < ActionView::TestCase
+end


### PR DESCRIPTION
On the game show page, each piece now links to an edit page for that piece.  The edit page appears similar to the game show page, except that all of the squares are links, which go to the update action on the pieces controller, updating the x and y positions of the piece.
 
This is extremely rough functionally, in that there are no validations for if the piece belongs to the current player or if the move is valid, it does not incorporate capturing, etc.  Wanted to get something up for people to see.  I'm curious if the way that I set up the edit/update actions here is going to meet our needs.

Also it isn't DRY, I definitely repeated myself, but again I want to make sure this approach will fit the project before I go back and refactor.