### PR TITLE
Valid moves

### DIFF
--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -1,2 +1,7 @@
 class Bishop < Piece
+	def legal_moves
+		accessible_squares.reject{|s| is_obstructed?(s[0],s[1])}.select do |s|
+			(x_position - s[0]).abs == (y_position - s[1]).abs
+		end
+	end
 end

--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -1,6 +1,6 @@
 class Bishop < Piece
 	def legal_moves
-		accessible_squares.reject{|s| is_obstructed?(s[0],s[1])}.select do |s|
+		unobstructed_squares.select do |s|
 			(x_position - s[0]).abs == (y_position - s[1]).abs
 		end
 	end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -1,6 +1,6 @@
 class King < Piece
 	def legal_moves
-		ALL_SQUARES.select do |s|
+		accessible_squares.select do |s|
 			distance_to(s[0],s[1]) == 1
 		end
 	end

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -1,2 +1,8 @@
 class Knight < Piece
+	def legal_moves
+		accessible_squares.select do |s|
+			(x_position - s[0]).abs + (y_position - s[1]).abs == 3 &&
+			x_position != s[0] && y_position != s[1]
+		end
+	end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,8 +1,9 @@
 class Pawn < Piece
   def legal_moves
     unobstructed_squares.select do |s|
-      # Must advance
-      color == "White" ? s[1] > y_position : s[1] < y_position
+      (forward_one?(s) && !occupied?(s)) ||
+      (forward_two?(s) && !occupied?(s) && has_not_moved) ||
+      (captures_diagonally?(s) && occupied?(s))
     end
   end
 
@@ -12,5 +13,39 @@ class Pawn < Piece
 
   def has_not_moved
     y_position == starting_rank
+  end
+
+  private
+
+  def advances?(square)
+    color == "White" ? square[1] > y_position : square[1] < y_position
+  end
+
+  def same_file?(square)
+    square[0] == x_position
+  end
+
+  def forward_one?(square)
+    advances?(square) &&
+    same_file?(square) &&
+    (square[1] - y_position).abs == 1
+  end
+
+  def forward_two?(square)
+    advances?(square) &&
+    same_file?(square) &&
+    (square[1] - y_position).abs == 2
+  end
+
+  def captures_diagonally?(square)
+    advances?(square) &&
+    (square[1] - y_position).abs == 1 &&
+    (square[1] - x_position).abs == 1
+  end
+
+  def occupied?(square)
+    game.pieces.any? do |piece|
+      piece.x_position == square[0] && piece.y_position == square[1]
+    end
   end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,2 +1,16 @@
 class Pawn < Piece
+  def legal_moves
+    unobstructed_squares.select do |s|
+      # Must advance
+      color == "White" ? s[1] > y_position : s[1] < y_position
+    end
+  end
+
+  def starting_rank
+    color == "White" ? 1 : 6
+  end
+
+  def has_not_moved
+    y_position == starting_rank
+  end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -19,7 +19,9 @@ class Piece < ActiveRecord::Base
   def accessible_squares
     ALL_SQUARES.reject do |square|
       game.pieces.any? do |piece|
-        square[0] == piece.x_position && square[1] == piece.y_position
+        player_id == piece.player_id &&
+        square[0] == piece.x_position && 
+        square[1] == piece.y_position
       end
     end
   end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -13,6 +13,17 @@ class Piece < ActiveRecord::Base
     [7, 0], [7, 1], [7, 2], [7, 3], [7, 4], [7, 5], [7, 6], [7, 7]
   ]
   
+  ##
+  # Pieces can only move to a square that is either unoccupied
+  # or occupied by an opponent's piece
+  def accessible_squares
+    ALL_SQUARES.reject do |square|
+      game.pieces.any? do |piece|
+        square[0] == piece.x_position && square[1] == piece.y_position
+      end
+    end
+  end
+
   def legal_move?(x,y)
     legal_moves.include?([x, y])
   end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -26,6 +26,13 @@ class Piece < ActiveRecord::Base
     end
   end
 
+  ##
+  # Use this method in place of accessible_squares for piece
+  # types whose moves can be obstructed
+  def unobstructed_squares
+    accessible_squares.reject{|s| is_obstructed?(s[0],s[1])}
+  end
+
   def legal_move?(x,y)
     legal_moves.include?([x, y])
   end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -90,8 +90,8 @@ class Piece < ActiveRecord::Base
 	  		self.vector_to(x,y) == self.vector_to(piece.x_position, piece.y_position) &&
 	  		self.distance_to(x,y) > self.distance_to(piece.x_position,piece.y_position)
 	  	end
-	  else
-	  	raise "Invalid input. Not diagonal, horizontal, or vertical."
+	  # else
+	  # 	raise "Invalid input. Not diagonal, horizontal, or vertical."
 	  end
   end
 

--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -1,6 +1,6 @@
 class Queen < Piece
 	def legal_moves
-		accessible_squares.reject{|s| is_obstructed?(s[0],s[1])}.select do |s|
+		unobstructed_squares.select do |s|
 			x_position == s[0] || y_position == s[1] ||
 			(x_position - s[0]).abs == (y_position - s[1]).abs
 		end

--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -1,2 +1,8 @@
 class Queen < Piece
+	def legal_moves
+		accessible_squares.reject{|s| is_obstructed?(s[0],s[1])}.select do |s|
+			x_position == s[0] || y_position == s[1] ||
+			(x_position - s[0]).abs == (y_position - s[1]).abs
+		end
+	end
 end

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -1,6 +1,6 @@
 class Rook < Piece
 	def legal_moves
-		accessible_squares.reject{|s| is_obstructed?(s[0],s[1])}.select do |s|
+		unobstructed_squares.select do |s|
 			x_position == s[0] || y_position == s[1]
 		end
 	end

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -1,2 +1,7 @@
 class Rook < Piece
+	def legal_moves
+		accessible_squares.reject{|s| is_obstructed?(s[0],s[1])}.select do |s|
+			x_position == s[0] || y_position == s[1]
+		end
+	end
 end

--- a/test/models/bishop_test.rb
+++ b/test/models/bishop_test.rb
@@ -30,10 +30,10 @@ class BishopTest < ActiveSupport::TestCase
   private
 
   def game_and_bishop
-    @game = Game.create(:name => 'lolomg', :white_player_id => 1)
+    @game = Game.create(name: 'lolomg', white_player_id: 1)
     @bishop = @game.pieces.create(
-      type: 'Bishop', 
-      x_position: 3, 
+      type: 'Bishop',
+      x_position: 3,
       y_position: 4,
       player_id: 1)
   end

--- a/test/models/bishop_test.rb
+++ b/test/models/bishop_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class BishopTest < ActiveSupport::TestCase
+  setup :game_and_bishop
+
+  test 'Illegal vertical move' do
+    assert_not @bishop.legal_move?(3, 5)
+  end
+
+  test 'Illegal horizontal move' do
+    assert_not @bishop.legal_move?(7, 4)
+  end
+
+  test 'Legal move, captures opponent piece' do
+    assert @bishop.legal_move?(5, 6)
+  end
+
+  test 'Legal diagonal move' do
+    assert @bishop.legal_move?(4, 5)
+  end
+
+  test 'Illegal obstructed move' do
+    assert_not @bishop.legal_move?(6, 7)
+  end
+
+  test 'Illegal move, own piece occupies square' do
+    assert_not @bishop.legal_move?(6, 1)
+  end
+
+  private
+
+  def game_and_bishop
+    @game = Game.create(:name => 'lolomg', :white_player_id => 1)
+    @bishop = @game.pieces.create(
+      type: 'Bishop', 
+      x_position: 3, 
+      y_position: 4,
+      player_id: 1)
+  end
+end

--- a/test/models/bishop_test.rb
+++ b/test/models/bishop_test.rb
@@ -27,6 +27,19 @@ class BishopTest < ActiveSupport::TestCase
     assert_not @bishop.legal_move?(6, 1)
   end
 
+  test 'Illegal move, not horizontal, vertical or diagonal' do
+    assert_not @bishop.legal_move?(4, 4)
+  end
+
+  test 'Illegal move, not on board' do
+    new_bishop = @game.pieces.create(
+      type: 'Bishop',
+      x_position: 7,
+      y_position: 3,
+      player_id: 1)
+    assert_not new_bishop.legal_move?(8, 4)
+  end
+
   private
 
   def game_and_bishop

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
 class GameTest < ActiveSupport::TestCase
-  test "correct number of pieces" do
-  	game = Game.create(:name => 'yolo', :white_player_id => 1)
+  test 'correct number of pieces' do
+    game = Game.create(name: 'yolo', white_player_id: 1)
     assert_equal game.pieces.count, 32
   end
 end

--- a/test/models/king_test.rb
+++ b/test/models/king_test.rb
@@ -4,21 +4,21 @@ class KingTest < ActiveSupport::TestCase
 	setup :game_and_king
 
   test 'Legal vertical move' do
-    assert @king.legal_move?(4, 1)
+    assert @king.legal_move?(4, 3)
   end
 
   test 'Legal diagonal move' do
-    assert @king.legal_move?(5, 1)
+    assert @king.legal_move?(5, 3)
   end
 
   test 'Illegal move' do
-    assert_not @king.legal_move?(5, 2)
+    assert_not @king.legal_move?(5, 4)
   end  
 
 	private
 
   def game_and_king
     @game = Game.create(:name => 'lolomg', :white_player_id => 1)
-    @king = @game.pieces.find_by(type: 'King', player_id: 1)
+    @king = @game.pieces.create(type: 'King', x_position: 4, y_position: 2)
   end
 end

--- a/test/models/king_test.rb
+++ b/test/models/king_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class KingTest < ActiveSupport::TestCase
-	setup :game_and_king
+  setup :game_and_king
 
   test 'Legal vertical move' do
     assert @king.legal_move?(4, 3)
@@ -13,12 +13,12 @@ class KingTest < ActiveSupport::TestCase
 
   test 'Illegal move' do
     assert_not @king.legal_move?(5, 4)
-  end  
+  end
 
-	private
+  private
 
   def game_and_king
-    @game = Game.create(:name => 'lolomg', :white_player_id => 1)
+    @game = Game.create(name: 'lolomg', white_player_id: 1)
     @king = @game.pieces.create(type: 'King', x_position: 4, y_position: 2)
   end
 end

--- a/test/models/king_test.rb
+++ b/test/models/king_test.rb
@@ -15,6 +15,15 @@ class KingTest < ActiveSupport::TestCase
     assert_not @king.legal_move?(5, 4)
   end
 
+  test 'Illegal move, not on board' do
+    new_king = @game.pieces.create(
+      type: 'King',
+      x_position: 7,
+      y_position: 3,
+      player_id: 1)
+    assert_not new_king.legal_move?(8, 3)
+  end
+
   private
 
   def game_and_king

--- a/test/models/knight_test.rb
+++ b/test/models/knight_test.rb
@@ -34,31 +34,31 @@ class KnightTest < ActiveSupport::TestCase
   private
 
   def game_and_knight
-    @game = Game.create(:name => 'lolomg', :white_player_id => 1)
+    @game = Game.create(name: 'lolomg', white_player_id: 1)
     @knight = @game.pieces.create(
-      type: 'Knight', 
-      x_position: 3, 
+      type: 'Knight',
+      x_position: 3,
       y_position: 3,
       player_id: 1)
     @black_pawn = @game.pieces.create(
-      type: 'Pawn', 
-      x_position: 4, 
-      y_position: 5, 
+      type: 'Pawn',
+      x_position: 4,
+      y_position: 5,
       player_id: 2)
     @white_pawn_1 = @game.pieces.create(
-      type: 'Pawn', 
-      x_position: 3, 
-      y_position: 4, 
+      type: 'Pawn',
+      x_position: 3,
+      y_position: 4,
       player_id: 1)
     @white_pawn_2 = @game.pieces.create(
-      type: 'Pawn', 
-      x_position: 4, 
-      y_position: 4, 
-      player_id: 1)    
+      type: 'Pawn',
+      x_position: 4,
+      y_position: 4,
+      player_id: 1)
     @white_pawn_3 = @game.pieces.create(
-      type: 'Pawn', 
-      x_position: 4, 
-      y_position: 3, 
+      type: 'Pawn',
+      x_position: 4,
+      y_position: 3,
       player_id: 1)
   end
 end

--- a/test/models/knight_test.rb
+++ b/test/models/knight_test.rb
@@ -1,0 +1,64 @@
+require 'test_helper'
+
+class KnightTest < ActiveSupport::TestCase
+  setup :game_and_knight
+
+  test 'Illegal vertical move' do
+    assert_not @knight.legal_move?(3, 2)
+  end
+
+  test 'Illegal horizontal move' do
+    assert_not @knight.legal_move?(0, 3)
+  end
+
+  test 'Legal move, captures opponent piece' do
+    assert @knight.legal_move?(4, 5)
+  end
+
+  test 'Illegal diagonal move' do
+    assert_not @knight.legal_move?(2, 2)
+  end
+
+  test 'Legal move, knight cannot be obstructed' do
+    assert @knight.legal_move?(4, 5)
+  end
+
+  test 'Illegal move, own piece occupies square' do
+    assert_not @knight.legal_move?(4, 1)
+  end
+
+  test 'Illegal move for all piece types' do
+    assert_not @knight.legal_move?(7, 5)
+  end
+
+  private
+
+  def game_and_knight
+    @game = Game.create(:name => 'lolomg', :white_player_id => 1)
+    @knight = @game.pieces.create(
+      type: 'Knight', 
+      x_position: 3, 
+      y_position: 3,
+      player_id: 1)
+    @black_pawn = @game.pieces.create(
+      type: 'Pawn', 
+      x_position: 4, 
+      y_position: 5, 
+      player_id: 2)
+    @white_pawn_1 = @game.pieces.create(
+      type: 'Pawn', 
+      x_position: 3, 
+      y_position: 4, 
+      player_id: 1)
+    @white_pawn_2 = @game.pieces.create(
+      type: 'Pawn', 
+      x_position: 4, 
+      y_position: 4, 
+      player_id: 1)    
+    @white_pawn_3 = @game.pieces.create(
+      type: 'Pawn', 
+      x_position: 4, 
+      y_position: 3, 
+      player_id: 1)
+  end
+end

--- a/test/models/knight_test.rb
+++ b/test/models/knight_test.rb
@@ -31,6 +31,15 @@ class KnightTest < ActiveSupport::TestCase
     assert_not @knight.legal_move?(7, 5)
   end
 
+  test 'Illegal move, not on board' do
+    new_knight = @game.pieces.create(
+      type: 'Knight',
+      x_position: 7,
+      y_position: 3,
+      player_id: 1)
+    assert_not new_knight.legal_move?(8, 5)
+  end
+
   private
 
   def game_and_knight

--- a/test/models/pawn_test.rb
+++ b/test/models/pawn_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+class PawnTest < ActiveSupport::TestCase
+  setup :game_and_pawn
+
+  test 'Pawn can advance 1 square' do
+    assert @first_pawn.legal_move?(1, 2)
+  end
+
+  test 'Pawn that has not moved can advance 2 squares' do
+    assert @first_pawn.legal_move?(1, 3)
+  end
+
+  test 'Pawn cannot move diagonally unless capturing' do
+    assert_not @first_pawn.legal_move?(2, 2)
+  end
+
+  test 'Pawn can move diagonally if capturing' do
+    @enemy_pawn = @game.pieces.create(
+      type: 'Pawn',
+      x_position: 2,
+      y_position: 2,
+      player_id: 2)
+    assert @first_pawn.legal_move?(2, 2)
+  end
+
+  test 'Pawn that has moved can no longer advance 2 squares' do
+    second_pawn.move!(6, 2)
+    assert_not @second_pawn.legal_move?(6, 4)
+  end
+
+  test 'Illegal move, own piece occupies square' do
+    assert_not @pawn.legal_move?(4, 1)
+  end
+
+  test 'Illegal move for all piece types' do
+    assert_not @pawn.legal_move?(7, 5)
+  end
+
+  private
+
+  def game_and_pawn
+    @game = Game.create(:name => 'lolomg', :white_player_id => 1, :black_player_id => 2)
+    @first_pawn = @game.pieces.find{|p| p.x_position == 1 && p.y_position == 1}
+    @second_pawn = @game.pieces.find{|p| p.x_position == 6 && p.y_position == 1}
+  end
+end

--- a/test/models/pawn_test.rb
+++ b/test/models/pawn_test.rb
@@ -11,9 +11,9 @@ class PawnTest < ActiveSupport::TestCase
     assert @first_pawn.legal_move?(1, 3)
   end
 
-  # test 'Pawn cannot move diagonally unless capturing' do
-  #   assert_not @first_pawn.legal_move?(2, 2)
-  # end
+  test 'Pawn cannot move diagonally unless capturing' do
+    assert_not @first_pawn.legal_move?(2, 2)
+  end
 
   test 'Pawn can move diagonally if capturing' do
     @enemy_pawn = @game.pieces.create(
@@ -24,10 +24,10 @@ class PawnTest < ActiveSupport::TestCase
     assert @first_pawn.legal_move?(2, 2)
   end
 
-  # test 'Pawn that has moved can no longer advance 2 squares' do
-  #   @second_pawn.move!(6, 2)
-  #   assert_not @second_pawn.legal_move?(6, 4)
-  # end
+  test 'Pawn that has moved can no longer advance 2 squares' do
+    @second_pawn.move!(6, 2)
+    assert_not @second_pawn.legal_move?(6, 4)
+  end
 
   test 'Black pawns advance down the file' do
     assert @third_pawn.legal_move?(2, 5)
@@ -42,9 +42,13 @@ class PawnTest < ActiveSupport::TestCase
     assert_not @fourth_pawn.legal_move?(5, 4)
   end
 
-  # test 'Pawn cannot capture vertically' do
-  #   assert_not @fourth_pawn.legal_move?(5, 5)
-  # end
+  test 'Pawn cannot capture vertically' do
+    assert_not @fourth_pawn.legal_move?(5, 5)
+  end
+
+  test 'Pawn just does not move like that' do
+    assert_not @fourth_pawn.legal_move?(4, 4)
+  end
 
   private
 

--- a/test/models/pawn_test.rb
+++ b/test/models/pawn_test.rb
@@ -11,9 +11,9 @@ class PawnTest < ActiveSupport::TestCase
     assert @first_pawn.legal_move?(1, 3)
   end
 
-  test 'Pawn cannot move diagonally unless capturing' do
-    assert_not @first_pawn.legal_move?(2, 2)
-  end
+  # test 'Pawn cannot move diagonally unless capturing' do
+  #   assert_not @first_pawn.legal_move?(2, 2)
+  # end
 
   test 'Pawn can move diagonally if capturing' do
     @enemy_pawn = @game.pieces.create(
@@ -24,18 +24,27 @@ class PawnTest < ActiveSupport::TestCase
     assert @first_pawn.legal_move?(2, 2)
   end
 
-  test 'Pawn that has moved can no longer advance 2 squares' do
-    second_pawn.move!(6, 2)
-    assert_not @second_pawn.legal_move?(6, 4)
-  end
+  # test 'Pawn that has moved can no longer advance 2 squares' do
+  #   @second_pawn.move!(6, 2)
+  #   assert_not @second_pawn.legal_move?(6, 4)
+  # end
 
   test 'Black pawns advance down the file' do
-    assert @pawn.legal_move?(2, 5)
+    assert @third_pawn.legal_move?(2, 5)
   end
 
-  test 'Illegal move for all piece types' do
-    assert_not @pawn.legal_move?(7, 5)
+  test 'Black pawns cannot move back up the file' do
+    @third_pawn.move!(2, 4)
+    assert_not @third_pawn.legal_move?(2, 5)
   end
+
+  test 'Pawn cannot advance 2 squares if obstructed' do
+    assert_not @fourth_pawn.legal_move?(5, 4)
+  end
+
+  # test 'Pawn cannot capture vertically' do
+  #   assert_not @fourth_pawn.legal_move?(5, 5)
+  # end
 
   private
 
@@ -44,5 +53,11 @@ class PawnTest < ActiveSupport::TestCase
     @first_pawn = @game.pieces.find { |p| p.x_position == 1 && p.y_position == 1 }
     @second_pawn = @game.pieces.find { |p| p.x_position == 6 && p.y_position == 1 }
     @third_pawn = @game.pieces.find { |p| p.x_position == 2 && p.y_position == 6 }
+    @fourth_pawn = @game.pieces.find { |p| p.x_position == 5 && p.y_position == 6 }
+    @fifth_pawn = @game.pieces.create(
+      type: 'Pawn',
+      x_position: 5,
+      y_position: 5,
+      player_id: 1)
   end
 end

--- a/test/models/pawn_test.rb
+++ b/test/models/pawn_test.rb
@@ -29,8 +29,8 @@ class PawnTest < ActiveSupport::TestCase
     assert_not @second_pawn.legal_move?(6, 4)
   end
 
-  test 'Illegal move, own piece occupies square' do
-    assert_not @pawn.legal_move?(4, 1)
+  test 'Black pawns advance down the file' do
+    assert @pawn.legal_move?(2, 5)
   end
 
   test 'Illegal move for all piece types' do
@@ -40,8 +40,9 @@ class PawnTest < ActiveSupport::TestCase
   private
 
   def game_and_pawn
-    @game = Game.create(:name => 'lolomg', :white_player_id => 1, :black_player_id => 2)
-    @first_pawn = @game.pieces.find{|p| p.x_position == 1 && p.y_position == 1}
-    @second_pawn = @game.pieces.find{|p| p.x_position == 6 && p.y_position == 1}
+    @game = Game.create(name: 'lolomg', white_player_id: 1, black_player_id: 2)
+    @first_pawn = @game.pieces.find { |p| p.x_position == 1 && p.y_position == 1 }
+    @second_pawn = @game.pieces.find { |p| p.x_position == 6 && p.y_position == 1 }
+    @third_pawn = @game.pieces.find { |p| p.x_position == 2 && p.y_position == 6 }
   end
 end

--- a/test/models/piece_test.rb
+++ b/test/models/piece_test.rb
@@ -3,93 +3,93 @@ require 'test_helper'
 class PieceTest < ActiveSupport::TestCase
   setup :initialize_board
 
-  test "white bishop is not obstructed" do
-    assert_not @white_bishop.is_obstructed?(2,3)
+  test 'white bishop is not obstructed' do
+    assert_not @white_bishop.is_obstructed?(2, 3)
   end
 
-  test "black bishop is obstructed" do
-    assert @black_bishop.is_obstructed?(3,2)
+  test 'black bishop is obstructed' do
+    assert @black_bishop.is_obstructed?(3, 2)
   end
 
-  test "black rook is obstructed" do
-    assert @black_rook.is_obstructed?(0,3)
+  test 'black rook is obstructed' do
+    assert @black_rook.is_obstructed?(0, 3)
   end
 
-  # test "knight cannot be obstructed" do
+  # test 'knight cannot be obstructed' do
   #   runtime_error = assert_raises(RuntimeError) do
   #     @white_knight.is_obstructed?(1,4)
   #   end
-  #   assert_equal("Invalid input. Not diagonal, horizontal, or vertical.", runtime_error.message)
+  #   assert_equal('Invalid input. Not diagonal, horizontal, or vertical.', runtime_error.message)
   # end
 
-  test "not obstructed piece in destination" do
-    assert_not @white_rook.is_obstructed?(0,5)
+  test 'not obstructed piece in destination' do
+    assert_not @white_rook.is_obstructed?(0, 5)
   end
 
-  test "not obstructed no piece in destination" do
-    assert_not @white_rook.is_obstructed?(2,7)
+  test 'not obstructed no piece in destination' do
+    assert_not @white_rook.is_obstructed?(2, 7)
   end
 
-  test "capture - valid, opponent piece" do
+  test 'capture - valid, opponent piece' do
     # white_bishop is at [0,5] from initialize_board
-    @black_bishop.capture_opponent!(0,5)
+    @black_bishop.capture_opponent!(0, 5)
     @white_bishop.reload
-    assert_equal [nil,nil], [@white_bishop.x_position, @white_bishop.y_position]
+    assert_equal [nil, nil], [@white_bishop.x_position, @white_bishop.y_position]
   end
 
-  test "capture - invalid, own piece" do
+  test 'capture - invalid, own piece' do
     # black_rook is at [0,0] from initialize_board
-    @black_bishop.capture_opponent!(0,0)
+    @black_bishop.capture_opponent!(0, 0)
     @black_rook.reload
-    assert_equal [0,0], [@black_rook.x_position, @black_rook.y_position]
+    assert_equal [0, 0], [@black_rook.x_position, @black_rook.y_position]
   end
 
-  test "move - invalid" do
-    @black_king.move!(4,2)
+  test 'move - invalid' do
+    @black_king.move!(4, 2)
     @black_king.reload
-    assert_equal [4,0], [@black_king.x_position, @black_king.y_position]
+    assert_equal [4, 0], [@black_king.x_position, @black_king.y_position]
   end
 
-  test "move - valid" do
-    @black_king.update_attributes(:x_position => 4, :y_position => 2)
-    @black_king.move!(4,3)
+  test 'move - valid' do
+    @black_king.update_attributes(x_position: 4, y_position: 2)
+    @black_king.move!(4, 3)
     @black_king.reload
-    assert_equal [4,3], [@black_king.x_position, @black_king.y_position]
+    assert_equal [4, 3], [@black_king.x_position, @black_king.y_position]
   end
 
-  test "move - valid with capture" do
-    @black_king.update_attributes(:x_position => 1, :y_position => 5)
-    @black_king.move!(1,6)
+  test 'move - valid with capture' do
+    @black_king.update_attributes(x_position: 1, y_position: 5)
+    @black_king.move!(1, 6)
     @black_king.reload
     @white_pawn2.reload
-    assert_equal [1,6], [@black_king.x_position, @black_king.y_position]
-    assert_equal [nil,nil], [@white_pawn2.x_position, @white_pawn2.y_position]
+    assert_equal [1, 6], [@black_king.x_position, @black_king.y_position]
+    assert_equal [nil, nil], [@white_pawn2.x_position, @white_pawn2.y_position]
   end
 
   private
 
   def initialize_board
-    @black_player = FactoryGirl.create(:user) 
-    @white_player = FactoryGirl.create(:user) 
+    @black_player = FactoryGirl.create(:user)
+    @white_player = FactoryGirl.create(:user)
 
     # create a game and the 32 pieces, select pieces to test
-    @game = Game.create(:name => 'lolomg', :black_player => @black_player, :white_player => @white_player)
-    @black_bishop = @game.pieces.find{|piece| piece.x_position == 5 && piece.y_position == 0}
-    @black_pawn = @game.pieces.find{|piece| piece.x_position == 2 && piece.y_position == 1}
-    @black_rook = @game.pieces.find{|piece| piece.x_position == 0 && piece.y_position == 0}
-    @black_king = @game.pieces.find{|piece| piece.x_position == 4 && piece.y_position == 0}
-    @white_bishop = @game.pieces.find{|piece| piece.x_position == 2 && piece.y_position == 7}
-    @white_knight = @game.pieces.find{|piece| piece.x_position == 1 && piece.y_position == 7}
-    @white_rook = @game.pieces.find{|piece| piece.x_position == 0 && piece.y_position == 7}
-    @white_pawn = @game.pieces.find{|piece| piece.x_position == 0 && piece.y_position == 6}
-    @white_pawn2 = @game.pieces.find{|piece| piece.x_position == 1 && piece.y_position == 6}
+    @game = Game.create(name: 'lolomg', black_player: @black_player, white_player: @white_player)
+    @black_bishop = @game.pieces.find { |piece| piece.x_position == 5 && piece.y_position == 0 }
+    @black_pawn = @game.pieces.find { |piece| piece.x_position == 2 && piece.y_position == 1 }
+    @black_rook = @game.pieces.find { |piece| piece.x_position == 0 && piece.y_position == 0 }
+    @black_king = @game.pieces.find { |piece| piece.x_position == 4 && piece.y_position == 0 }
+    @white_bishop = @game.pieces.find { |piece| piece.x_position == 2 && piece.y_position == 7 }
+    @white_knight = @game.pieces.find { |piece| piece.x_position == 1 && piece.y_position == 7 }
+    @white_rook = @game.pieces.find { |piece| piece.x_position == 0 && piece.y_position == 7 }
+    @white_pawn = @game.pieces.find { |piece| piece.x_position == 0 && piece.y_position == 6 }
+    @white_pawn2 = @game.pieces.find { |piece| piece.x_position == 1 && piece.y_position == 6 }
     # remove the pawn at A7 from the board
     @white_pawn.destroy
-    # move the bishop from C8 to A6 
-    @white_bishop.update_attributes(:x_position => 0, :y_position => 5)
+    # move the bishop from C8 to A6
+    @white_bishop.update_attributes(x_position: 0, y_position: 5)
     # move the knight from B8 to D4
-    @white_knight.update_attributes(:x_position => 3, :y_position => 3)
+    @white_knight.update_attributes(x_position: 3, y_position: 3)
     # move the pawn from C2 to C4
-    @black_pawn.update_attributes(:x_position => 2, :y_position => 3)
+    @black_pawn.update_attributes(x_position: 2, y_position: 3)
   end
 end

--- a/test/models/piece_test.rb
+++ b/test/models/piece_test.rb
@@ -15,12 +15,12 @@ class PieceTest < ActiveSupport::TestCase
     assert @black_rook.is_obstructed?(0,3)
   end
 
-  test "knight cannot be obstructed" do
-    runtime_error = assert_raises(RuntimeError) do
-      @white_knight.is_obstructed?(1,4)
-    end
-    assert_equal("Invalid input. Not diagonal, horizontal, or vertical.", runtime_error.message)
-  end
+  # test "knight cannot be obstructed" do
+  #   runtime_error = assert_raises(RuntimeError) do
+  #     @white_knight.is_obstructed?(1,4)
+  #   end
+  #   assert_equal("Invalid input. Not diagonal, horizontal, or vertical.", runtime_error.message)
+  # end
 
   test "not obstructed piece in destination" do
     assert_not @white_rook.is_obstructed?(0,5)

--- a/test/models/queen_test.rb
+++ b/test/models/queen_test.rb
@@ -31,6 +31,10 @@ class QueenTest < ActiveSupport::TestCase
     assert_not @queen.legal_move?(8, 3)
   end
 
+  test 'Illegal move, not horizontal, vertical or diagonal' do
+    assert_not @queen.legal_move?(5, 4)
+  end
+
   private
 
   def game_and_queen

--- a/test/models/queen_test.rb
+++ b/test/models/queen_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class QueenTest < ActiveSupport::TestCase
+  setup :game_and_queen
+
+  test 'Legal vertical move' do
+    assert @queen.legal_move?(3, 4)
+  end
+
+  test 'Legal horizontal move' do
+    assert @queen.legal_move?(7, 3)
+  end
+
+  test 'Legal move, captures opponent piece' do
+    assert @queen.legal_move?(3, 6)
+  end
+
+  test 'Legal diagonal move' do
+    assert @queen.legal_move?(4, 4)
+  end
+
+  test 'Illegal obstructed move' do
+    assert_not @queen.legal_move?(3, 7)
+  end
+
+  test 'Illegal move, own piece occupies square' do
+    assert_not @queen.legal_move?(3, 1)
+  end
+
+  test 'Illegal move, not on board' do
+    assert_not @queen.legal_move?(8, 3)
+  end
+
+  private
+
+  def game_and_queen
+    @game = Game.create(:name => 'lolomg', :white_player_id => 1)
+    @queen = @game.pieces.create(
+      type: 'Queen', 
+      x_position: 3, 
+      y_position: 3,
+      player_id: 1)
+  end
+end

--- a/test/models/queen_test.rb
+++ b/test/models/queen_test.rb
@@ -34,10 +34,10 @@ class QueenTest < ActiveSupport::TestCase
   private
 
   def game_and_queen
-    @game = Game.create(:name => 'lolomg', :white_player_id => 1)
+    @game = Game.create(name: 'lolomg', white_player_id: 1)
     @queen = @game.pieces.create(
-      type: 'Queen', 
-      x_position: 3, 
+      type: 'Queen',
+      x_position: 3,
       y_position: 3,
       player_id: 1)
   end

--- a/test/models/rook_test.rb
+++ b/test/models/rook_test.rb
@@ -3,10 +3,6 @@ require 'test_helper'
 class RookTest < ActiveSupport::TestCase
   setup :game_and_rook
 
-  test '3,7 is obstructed' do
-    assert @rook.is_obstructed?(3, 7)
-  end
-
   test 'Legal vertical move' do
     assert @rook.legal_move?(3, 5)
   end

--- a/test/models/rook_test.rb
+++ b/test/models/rook_test.rb
@@ -34,10 +34,10 @@ class RookTest < ActiveSupport::TestCase
   private
 
   def game_and_rook
-    @game = Game.create(:name => 'lolomg', :white_player_id => 1)
+    @game = Game.create(name: 'lolomg', white_player_id: 1)
     @rook = @game.pieces.create(
-      type: 'Rook', 
-      x_position: 3, 
+      type: 'Rook',
+      x_position: 3,
       y_position: 4,
       player_id: 1)
   end

--- a/test/models/rook_test.rb
+++ b/test/models/rook_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class RookTest < ActiveSupport::TestCase
+  setup :game_and_rook
+
+  test '3,7 is obstructed' do
+    assert @rook.is_obstructed?(3, 7)
+  end
+
+  test 'Legal vertical move' do
+    assert @rook.legal_move?(3, 5)
+  end
+
+  test 'Legal horizontal move' do
+    assert @rook.legal_move?(7, 4)
+  end
+
+  test 'Legal move, captures opponent piece' do
+    assert @rook.legal_move?(3, 6)
+  end
+
+  test 'Illegal diagonal move' do
+    assert_not @rook.legal_move?(4, 5)
+  end
+
+  test 'Illegal obstructed move' do
+    assert_not @rook.legal_move?(3, 7)
+  end
+
+  test 'Illegal move, own piece occupies square' do
+    assert_not @rook.legal_move?(3, 1)
+  end
+
+  test 'Illegal move, not on board' do
+    assert_not @rook.legal_move?(8, 4)
+  end
+
+  private
+
+  def game_and_rook
+    @game = Game.create(:name => 'lolomg', :white_player_id => 1)
+    @rook = @game.pieces.create(
+      type: 'Rook', 
+      x_position: 3, 
+      y_position: 4,
+      player_id: 1)
+  end
+end


### PR DESCRIPTION
- Created an accessible_squares method on the Piece model, which returns the squares that are 1) on the board and 2) either unoccupied or contain an opponents piece.  Legal_moves for each piece type can call this instead of ALL_SQUARES.

- When testing rook moves, I commented out the part of the is_obstructed? method that raises an exception, because it was resulting in Errors in the tests.  It didn't seem like we needed an exception, because all cases that could result in an exception would be invalid moves for other reasons and would be caught by other methods.

- legal_move? method now functions appropriately for both king and rook.