### PR TITLE
Moved validation from check? to accessible_squares

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -11,10 +11,8 @@ class Game < ActiveRecord::Base
     opponent_pieces = self.pieces.where.not(player_id: player_id)
     opponent_moves = []
     opponent_pieces.each do |piece|
-      if piece.x_position && piece.y_position
-        piece.legal_moves.each do |square|
-          opponent_moves.push(square)
-        end
+      piece.legal_moves.each do |square|
+        opponent_moves.push(square)
       end
     end
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -17,6 +17,7 @@ class Piece < ActiveRecord::Base
   # Pieces can only move to a square that is either unoccupied
   # or occupied by an opponent's piece
   def accessible_squares
+    return [] unless x_position && y_position
     ALL_SQUARES.reject do |square|
       game.pieces.any? do |piece|
         player_id == piece.player_id &&

--- a/test/models/piece_test.rb
+++ b/test/models/piece_test.rb
@@ -66,6 +66,15 @@ class PieceTest < ActiveSupport::TestCase
     assert_equal [nil, nil], [@white_pawn2.x_position, @white_pawn2.y_position]
   end
 
+  test 'captured piece has no legal moves' do
+    @black_king.update_attributes(x_position: 1, y_position: 5)
+    @black_king.move!(1, 6)
+    @black_king.reload
+    @white_pawn2.reload
+    assert_equal [nil, nil], [@white_pawn2.x_position, @white_pawn2.y_position]
+    assert_empty @white_pawn2.legal_moves
+  end
+
   private
 
   def initialize_board


### PR DESCRIPTION
This was what I was imagining in my comment about moving the validations.
Now there's no need to validate whether a piece has been captured when calling the `check?` method, because calling `legal_moves` on a captured piece no longer raises an exception, it just returns and empty array.