### PR TITLE
Added turn to games and method to change turns

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -16,7 +16,7 @@ class Game < ActiveRecord::Base
     turn == white_player_id ? black_player_id : white_player_id
   end
 
-  def change_turns
+  def change_turns!
     update_attributes(turn: opponent)
   end
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -6,6 +6,19 @@ class Game < ActiveRecord::Base
   validates :name, presence: true
 
   after_create :populate_board!
+  after_create :set_default_turn!
+
+  def set_default_turn!
+    update_attributes(turn: white_player_id)
+  end
+
+  def opponent
+    turn == white_player_id ? black_player_id : white_player_id
+  end
+
+  def change_turns
+    update_attributes(turn: opponent)
+  end
 
   def check?
     false

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -107,7 +107,7 @@ class Piece < ActiveRecord::Base
     if self.legal_move?(x,y)
       self.capture_opponent!(x,y)
       self.update_attributes(x_position: x, y_position: y, moved: true)
-      game.change_turns
+      game.change_turns!
     end
   end
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -103,10 +103,12 @@ class Piece < ActiveRecord::Base
   # Check and capture opponent's piece if there is
   # Move the actual piec
 
-  def move!(x, y)
-    return unless legal_move?(x, y)
-    capture_opponent!(x, y)
-    update_attributes(x_position: x, y_position: y, moved: true)
+  def move!(x,y)
+    if self.legal_move?(x,y)
+      self.capture_opponent!(x,y)
+      self.update_attributes(x_position: x, y_position: y, moved: true)
+      game.change_turns
+    end
   end
 
   ##

--- a/db/migrate/20151220134723_add_turn_to_games.rb
+++ b/db/migrate/20151220134723_add_turn_to_games.rb
@@ -1,0 +1,5 @@
+class AddTurnToGames < ActiveRecord::Migration
+  def change
+    add_column :games, :turn, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151208062017) do
+ActiveRecord::Schema.define(version: 20151220134723) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20151208062017) do
     t.datetime "updated_at"
     t.integer  "white_player_id"
     t.integer  "black_player_id"
+    t.integer  "turn"
   end
 
   create_table "pieces", force: true do |t|

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -11,11 +11,26 @@ class GameTest < ActiveSupport::TestCase
   	assert_equal game.turn, game.white_player_id
   end
 
+  test 'black player is opponent at start of game' do
+    game = Game.create(name: 'yolo', white_player_id: 1)
+    assert_equal game.opponent, game.black_player_id
+  end
+
   test 'turn changes after player moves' do
   	game = Game.create(name: 'yolo', white_player_id: 1)
+    assert_equal game.turn, game.white_player_id
   	pawn = game.pieces.find_by(type: 'Pawn', player_id: 1)
   	pawn.move!(pawn.x_position, (pawn.y_position + 1))
   	game.reload
-  	assert_equal game.black_player_id, game.turn
+  	assert_equal game.turn, game.black_player_id
+  end
+
+  test 'player becomes opponent after move' do
+    game = Game.create(name: 'yolo', white_player_id: 1)
+    assert_equal game.opponent, game.black_player_id
+    pawn = game.pieces.find_by(type: 'Pawn', player_id: 1)
+    pawn.move!(pawn.x_position, (pawn.y_position + 1))
+    game.reload
+    assert_equal game.opponent, game.white_player_id
   end
 end

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -5,4 +5,17 @@ class GameTest < ActiveSupport::TestCase
     game = Game.create(name: 'yolo', white_player_id: 1)
     assert_equal game.pieces.count, 32
   end
+
+  test 'white player should go first' do
+  	game = Game.create(name: 'yolo', white_player_id: 1)
+  	assert_equal game.turn, game.white_player_id
+  end
+
+  test 'turn changes after player moves' do
+  	game = Game.create(name: 'yolo', white_player_id: 1)
+  	pawn = game.pieces.find_by(type: 'Pawn', player_id: 1)
+  	pawn.move!(pawn.x_position, (pawn.y_position + 1))
+  	game.reload
+  	assert_equal game.black_player_id, game.turn
+  end
 end


### PR DESCRIPTION
- Added turn to games table
- After create callback on the games model sets the starting turn to white_player_id
- Added line to move! method, calls another method that changes turn to the opponent's player_id

I did not include a turn counter at this time.  I discussed with @kenwmak and we agreed that the changing turns functionality was most important.