### PR TITLE
Added en passant capture logic

### DIFF
--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -3,7 +3,8 @@ class Pawn < Piece
     unobstructed_squares.select do |s|
       (forward_one?(s) && !occupied?(s)) ||
         (forward_two?(s) && !occupied?(s) && not_moved) ||
-        (captures_diagonally?(s) && occupied?(s))
+        (captures_diagonally?(s) && occupied?(s)) ||
+        (captures_diagonally?(s) && en_passant_capture?(s))
     end
   end
 
@@ -46,6 +47,14 @@ class Pawn < Piece
   def occupied?(square)
     game.pieces.any? do |piece|
       piece.x_position == square[0] && piece.y_position == square[1]
+    end
+  end
+
+  def en_passant_capture?(square)
+    game.pieces.any? do |piece|
+      piece.x_position == square[0] &&
+        piece.y_position == y_position &&
+        piece.en_passant
     end
   end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,10 +1,13 @@
 class Pawn < Piece
   def legal_moves
     unobstructed_squares.select do |s|
-      (forward_one?(s) && !occupied?(s)) ||
-        (forward_two?(s) && !occupied?(s) && not_moved) ||
-        (captures_diagonally?(s) && occupied?(s)) ||
-        (captures_diagonally?(s) && en_passant_capture?(s))
+      if !occupied?(s)
+        forward_one?(s) ||
+          (forward_two?(s) && not_moved) ||
+          (captures_diagonally?(s) && en_passant_capture?(s))
+      else
+        captures_diagonally?(s)
+      end
     end
   end
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -105,6 +105,16 @@ class Piece < ActiveRecord::Base
 
   def move!(x, y)
     return unless legal_move?(x, y)
+    flagged = game.pieces.find_by(en_passant: true)
+    if type == 'Pawn'
+      if captures_diagonally?([x, y]) && !occupied?([x, y])
+        capture_opponent!(flagged.x_position, flagged.y_position)
+      end
+    end
+    flagged.update_attribute(:en_passant, false) if flagged
+    if type == 'Pawn' && (y - y_position).abs == 2
+      update_attribute(:en_passant, true)
+    end
     capture_opponent!(x, y)
     update_attributes(x_position: x, y_position: y, moved: true)
   end

--- a/db/migrate/20151221203633_add_en_passant_to_pieces.rb
+++ b/db/migrate/20151221203633_add_en_passant_to_pieces.rb
@@ -1,0 +1,5 @@
+class AddEnPassantToPieces < ActiveRecord::Migration
+  def change
+    add_column :pieces, :en_passant, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151208062017) do
+ActiveRecord::Schema.define(version: 20151221203633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20151208062017) do
     t.datetime "updated_at"
     t.integer  "white_player_id"
     t.integer  "black_player_id"
+    t.integer  "turn"
   end
 
   create_table "pieces", force: true do |t|
@@ -33,6 +34,7 @@ ActiveRecord::Schema.define(version: 20151208062017) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "moved",      default: false
+    t.boolean  "en_passant"
   end
 
   create_table "users", force: true do |t|

--- a/test/models/pawn_test.rb
+++ b/test/models/pawn_test.rb
@@ -50,6 +50,62 @@ class PawnTest < ActiveSupport::TestCase
     assert_not @fourth_pawn.legal_move?(4, 4)
   end
 
+  test 'Pawn starts with en passant flag nil' do
+    game = Game.create(name: 'lolomg', white_player_id: 1, black_player_id: 2)
+    white_pawn = game.pieces.find_by(x_position: 4, y_position: 1)
+    assert_nil white_pawn.en_passant
+  end
+
+  test 'Pawn advances 2, en passant flag true' do
+    game = Game.create(name: 'lolomg', white_player_id: 1, black_player_id: 2)
+    white_pawn = game.pieces.find_by(x_position: 4, y_position: 1)
+    white_pawn.move!(4, 3)
+    assert white_pawn.en_passant
+    assert white_pawn.x_position == 4 && white_pawn.y_position == 3
+  end
+
+  test 'Opponent moves, en passant resets to false' do
+    game = Game.create(name: 'lolomg', white_player_id: 1, black_player_id: 2)
+    white_pawn = game.pieces.find_by(x_position: 4, y_position: 1)
+    white_pawn.move!(4, 3)
+    assert white_pawn.en_passant
+    black_pawn = game.pieces.find_by(x_position: 3, y_position: 6)
+    black_pawn.move!(3, 4)
+    white_pawn.reload
+    assert_not white_pawn.en_passant
+  end
+
+  test 'En passant is legal move for pawn' do
+    game = Game.create(name: 'lolomg', white_player_id: 1, black_player_id: 2)
+    white_pawn = game.pieces.find_by(x_position: 4, y_position: 1)
+    white_pawn.move!(4, 3)
+    black_knight = game.pieces.find_by(x_position: 6, y_position: 7)
+    black_knight.move!(5, 5)
+    white_pawn.move!(4, 4)
+    black_pawn = game.pieces.find_by(x_position: 3, y_position: 6)
+    black_pawn.move!(3, 4)
+    white_pawn.reload
+    assert white_pawn.legal_move?(3, 5)
+  end
+
+  test 'En passant captures opponent pawn' do
+    game = Game.create(name: 'lolomg', white_player_id: 1, black_player_id: 2)
+    white_pawn = game.pieces.find_by(x_position: 4, y_position: 1)
+    white_pawn.move!(4, 3)
+    black_knight = game.pieces.find_by(x_position: 6, y_position: 7)
+    black_knight.move!(5, 5)
+    white_pawn.move!(4, 4)
+    black_pawn = game.pieces.find_by(x_position: 3, y_position: 6)
+    black_pawn.move!(3, 4)
+    white_pawn.reload
+    assert white_pawn.legal_move?(3, 5)
+    white_pawn.move!(3, 5)
+    white_pawn.reload
+    black_pawn.reload
+    assert_equal [3, 5], [white_pawn.x_position, white_pawn.y_position]
+    assert_equal [nil, nil], [black_pawn.x_position, black_pawn.y_position]
+  end
+
   private
 
   def game_and_pawn


### PR DESCRIPTION
- Added en_passant column to pieces table.
- Added logic to the `move!` method:
  - Moving a pawn forward 2 squares changes its en_passant value to `true`.
  - The value is then changed back to `false` after the opponent's next move, whether or not that next move is to capture the pawn en passant.
  - Only pawns can *capture* en passant, and only pawns can *be captured* en passant; an en_passant value of `true` indicates that this is a pawn that can *be captured* en passant.
- Added logic on the Pawn model to determine whether the pawn can *capture* en passant.
  - Takes into account both the presence of a `true` flag on an opponent's pawn and the relative positions of the pieces.
  - Makes en passant a `legal_move`.
- Added additional logic to the `move!` method so that after an en passant move is made, the `capture_opponent` method is correctly applied to the opponent's pawn.