### PR TITLE
Incorporated the move logic into piece controller, fixed bug in pawn's legal moves logic

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -7,7 +7,7 @@ class PiecesController < ApplicationController
 	def update
     @piece = Piece.find(params[:id])
     @game = @piece.game
-    @piece.update_attributes(piece_params)
+    flash[:alert] = 'Not a valid move' if !@piece.move!(piece_params[:x_position].to_i, piece_params[:y_position].to_i)
     render nothing: true
 	end
 

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -4,12 +4,12 @@ class PiecesController < ApplicationController
     @game = @piece.game
 	end
 
-	def update
+  def update
     @piece = Piece.find(params[:id])
     @game = @piece.game
     flash[:alert] = 'Not a valid move' if !@piece.move!(piece_params[:x_position].to_i, piece_params[:y_position].to_i)
     render nothing: true
-	end
+  end
 
   private
 

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -3,7 +3,7 @@ class Pawn < Piece
     unobstructed_squares.select do |s|
       (forward_one?(s) && !occupied?(s)) ||
         (forward_two?(s) && !occupied?(s) && not_moved) ||
-        (captures_diagonally?(s) && occupied?(s))
+        (captures_diagonally?(s))
     end
   end
 
@@ -38,9 +38,11 @@ class Pawn < Piece
   end
 
   def captures_diagonally?(square)
+    opponent_pieces = game.pieces.where.not(player_id: player_id)
     advances?(square) &&
       (square[1] - y_position).abs == 1 &&
-      (square[1] - x_position).abs == 1
+      (square[0] - x_position).abs == 1 &&
+      opponent_pieces.any? { |piece| piece.x_position == square[0] && piece.y_position == square[1] }
   end
 
   def occupied?(square)

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -3,7 +3,7 @@ class Pawn < Piece
     unobstructed_squares.select do |s|
       (forward_one?(s) && !occupied?(s)) ||
         (forward_two?(s) && !occupied?(s) && not_moved) ||
-        (captures_diagonally?(s))
+        captures_diagonally?(s)
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Chess::Application.routes.draw do
-  #devise_for :users
   devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }
 
   resources :games do

--- a/test/controllers/pieces_controller_test.rb
+++ b/test/controllers/pieces_controller_test.rb
@@ -1,7 +1,42 @@
 require 'test_helper'
 
 class PiecesControllerTest < ActionController::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup :game_setup
+
+  test 'update - moved' do
+    put :update, id: @white_pawn, piece: {x_position: 1, y_position: 3}
+    assert_response :success
+    @white_pawn.reload
+    assert_equal 3, @white_pawn.y_position
+  end
+
+  test 'update - not moved' do
+    put :update, id: @white_pawn, piece: {x_position: 1, y_position: 4}
+    assert_equal 'Not a valid move', flash[:alert]
+    @white_pawn.reload
+    assert_equal 1, @white_pawn.y_position
+  end
+
+  test 'update - moved, with capture' do
+    @black_pawn.update_attributes(x_position: 2, y_position: 2)
+    @white_pawn.reload
+    @black_pawn.reload
+    put :update, id: @white_pawn, piece: {x_position: 2, y_position: 2}
+    assert_response :success
+    @white_pawn.reload
+    @black_pawn.reload
+    assert_equal [2,2], [@white_pawn.x_position, @white_pawn.y_position]
+    assert_equal [nil,nil], [@black_pawn.x_position, @black_pawn.y_position]
+  end
+
+  private
+
+  def game_setup
+    @white_player = FactoryGirl.create(:user)
+    @black_player = FactoryGirl.create(:user)
+    sign_in @white_player
+    @game = Game.create(name: 'test', white_player_id: @white_player.id, black_player_id: @black_player.id)
+    @white_pawn = @game.pieces.find_by(type: 'Pawn', player_id: @white_player.id, x_position: 1)
+    @black_pawn = @game.pieces.find_by(type: 'Pawn', player_id: @black_player.id, x_position: 1)
+  end
 end

--- a/test/controllers/pieces_controller_test.rb
+++ b/test/controllers/pieces_controller_test.rb
@@ -19,8 +19,6 @@ class PiecesControllerTest < ActionController::TestCase
 
   test 'update - moved, with capture' do
     @black_pawn.update_attributes(x_position: 2, y_position: 2)
-    @white_pawn.reload
-    @black_pawn.reload
     put :update, id: @white_pawn, piece: {x_position: 2, y_position: 2}
     assert_response :success
     @white_pawn.reload


### PR DESCRIPTION
* Updated ```pieces#update``` action to use ```move!()```, so now frontend calling this action would update the piece's position in backend and capture any opponent pieces
* Found and fixed a bug with pawn's ```legal_moves```. Now it checks pawn's diagonal squares if there are opponents pieces and include them as legal_moves.