### PR TITLE
Added test coverage to pawns, fixed typo causing errors

### DIFF
--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -44,7 +44,7 @@ class Pawn < Piece
   def captures_diagonally?(square)
     advances?(square) &&
       (square[1] - y_position).abs == 1 &&
-      (square[1] - x_position).abs == 1
+      (square[0] - x_position).abs == 1
   end
 
   def occupied?(square)

--- a/test/models/pawn_test.rb
+++ b/test/models/pawn_test.rb
@@ -106,6 +106,21 @@ class PawnTest < ActiveSupport::TestCase
     assert_equal [nil, nil], [black_pawn.x_position, black_pawn.y_position]
   end
 
+  test 'Fix bug in valid diagonal moves' do
+    game = Game.create(name: 'lolomg', white_player_id: 1, black_player_id: 2)
+    white_pawn = game.pieces.find_by(x_position: 0, y_position: 1)
+    white_pawn.move!(0, 3)
+    black_pawn = game.pieces.find_by(x_position: 1, y_position: 6)
+    black_pawn.move!(1, 4)
+    white_pawn.reload
+    assert white_pawn.legal_move?(1, 4)
+    white_pawn.move!(1, 4)
+    white_pawn.reload
+    black_pawn.reload
+    assert_equal [1, 4], [white_pawn.x_position, white_pawn.y_position]
+    assert_equal [nil, nil], [black_pawn.x_position, black_pawn.y_position]
+  end
+
   private
 
   def game_and_pawn


### PR DESCRIPTION
Diagonal capture logic for pawns was not correctly checking the x-position of valid moves.  Added a test for a pawn capturing near the side of the board rather than in the center.
